### PR TITLE
feat(mail): add smtp and mailgun mail settings

### DIFF
--- a/platform-api/templates/api-worker.yml
+++ b/platform-api/templates/api-worker.yml
@@ -90,11 +90,53 @@ spec:
           value: {{ .Values.config.db.password | quote }}
           {{- end }}
         - name: HDX_URL
-          value: {{ .Values.config.hdx_url }}
+          value: {{ .Values.config.hdx_url | quote }}
         - name: MAIL_ADDRESS
-          value: {{ .Values.config.mail_from.address }}
+          value: {{ .Values.config.mail_from.address | quote }}
         - name: MAIL_NAME
-          value: {{ .Values.config.mail_from.name }}
+          value: {{ .Values.config.mail_from.name | quote }}
+        {{- if .Values.config.smtp_mail }}
+        - name: MAIL_DRIVER
+          value: smtp
+        - name: MAIL_HOST
+          value: {{ .Values.config.smtp_mail.host | quote }}
+        - name: MAIL_PORT
+          value: {{ .Values.config.smtp_mail.port | default "587" | quote }}
+        - name: MAIL_ENCRYPTION
+          value: {{ .Values.config.smtp_mail.encryption | default "tls" | quote }}
+        {{- if .Values.config.smtp_mail.username }}
+        - name: MAIL_USERNAME
+          value: {{ .Values.config.smtp_mail.username | quote }}
+        {{- end }}
+        {{- if .Values.config.smtp_mail.password }}
+        - name: MAIL_PASSWORD
+          value: {{ .Values.config.smtp_mail.password | quote }}
+        {{- end }}
+        {{- if .Values.config.smtp_mail.password_secret }}
+        - name: MAIL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.config.smtp_mail.password_secret.name }}
+              key: {{ .Values.config.smtp_mail.password_secret.key }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.config.mailgun_mail }}
+        - name: MAIL_DRIVER
+          value: mailgun
+        - name: MAILGUN_DOMAIN
+          value: {{ .Values.config.mailgun_mail.domain | quote }}
+        {{- if .Values.config.mailgun_mail.secret }}
+        - name: MAILGUN_SECRET
+          value: {{ .Values.config.mailgun_mail.secret | quote }}
+        {{- end }}
+        {{- if .Values.config.mailgun_mail.secret_ref }}
+        - name: MAILGUN_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.config.mailgun_mail.secret_ref.name }}
+              key: {{ .Values.config.mailgun_mail.secret_ref.key }}
+        {{- end }}
+        {{- end }}
         - name: REDIS_HOST
           value: {{ .Values.config.redis.host }}
         - name: REDIS_PORT
@@ -274,11 +316,53 @@ spec:
           value: {{ .Values.config.db.password | quote }}
           {{- end }}
         - name: HDX_URL
-          value: {{ .Values.config.hdx_url }}
+          value: {{ .Values.config.hdx_url | quote }}
         - name: MAIL_ADDRESS
-          value: {{ .Values.config.mail_from.address }}
+          value: {{ .Values.config.mail_from.address | quote }}
         - name: MAIL_NAME
-          value: {{ .Values.config.mail_from.name }}
+          value: {{ .Values.config.mail_from.name | quote }}
+        {{- if .Values.config.smtp_mail }}
+        - name: MAIL_DRIVER
+          value: smtp
+        - name: MAIL_HOST
+          value: {{ .Values.config.smtp_mail.host | quote }}
+        - name: MAIL_PORT
+          value: {{ .Values.config.smtp_mail.port | default "587" | quote }}
+        - name: MAIL_ENCRYPTION
+          value: {{ .Values.config.smtp_mail.encryption | default "tls" | quote }}
+        {{- if .Values.config.smtp_mail.username }}
+        - name: MAIL_USERNAME
+          value: {{ .Values.config.smtp_mail.username | quote }}
+        {{- end }}
+        {{- if .Values.config.smtp_mail.password }}
+        - name: MAIL_PASSWORD
+          value: {{ .Values.config.smtp_mail.password | quote }}
+        {{- end }}
+        {{- if .Values.config.smtp_mail.password_secret }}
+        - name: MAIL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.config.smtp_mail.password_secret.name }}
+              key: {{ .Values.config.smtp_mail.password_secret.key }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.config.mailgun_mail }}
+        - name: MAIL_DRIVER
+          value: mailgun
+        - name: MAILGUN_DOMAIN
+          value: {{ .Values.config.mailgun_mail.domain | quote }}
+        {{- if .Values.config.mailgun_mail.secret }}
+        - name: MAILGUN_SECRET
+          value: {{ .Values.config.mailgun_mail.secret | quote }}
+        {{- end }}
+        {{- if .Values.config.mailgun_mail.secret_ref }}
+        - name: MAILGUN_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.config.mailgun_mail.secret_ref.name }}
+              key: {{ .Values.config.mailgun_mail.secret_ref.key }}
+        {{- end }}
+        {{- end }}
         - name: REDIS_HOST
           value: {{ .Values.config.redis.host }}
         - name: REDIS_PORT

--- a/platform-api/values.yaml
+++ b/platform-api/values.yaml
@@ -31,6 +31,21 @@ config:
   mail_from:
     address: admin@example.com
     name: "Platform Deployment Admin"
+  # smtp_mail:
+  #   host:
+  #   port: 587
+  #   encryption: tls
+  #   username:
+  #   password
+  #   password_secret:
+  #     name:
+  #     key:
+  # mailgun_mail:
+  #   domain:
+  #   secret:
+  #   secret_ref:
+  #     name:
+  #     key:
   ##
   ## Additional settings provided in .env file, note that this only works for
   ## versions after commit


### PR DESCRIPTION
This adds smtp and mailgun settings handling from the chart's values, so that we don't have to resort to the dotenv for these settings.